### PR TITLE
fix: Use sys.executable for mlx_lm subprocess call

### DIFF
--- a/src/plamo_translate/servers/mlx/server.py
+++ b/src/plamo_translate/servers/mlx/server.py
@@ -4,6 +4,7 @@ import importlib.resources
 import logging
 import os
 import subprocess
+import sys
 from typing import Callable, Tuple
 
 import mlx.core as mx
@@ -88,7 +89,7 @@ class PLaMoTranslateServer(FastMCP):
             envs = os.environ
             envs["HF_HUB_DISABLE_PROGRESS_BARS"] = "0"
             subprocess.run(
-                ["python", "-m", "mlx_lm", "generate", "--model", model_name, "--max-tokens", "1"],
+                [sys.executable, "-m", "mlx_lm", "generate", "--model", model_name, "--max-tokens", "1"],
                 env=envs,
                 stdout=subprocess.DEVNULL,
             )


### PR DESCRIPTION
## Background
The `plamo-translate` command, installed with `uv tool install -p 3.12 plamo-translate`, failed with the following error:

```
$ plamo-translate
Process Process-1:
Traceback (most recent call last):
  File "/Users/katasetakumi/.local/share/uv/python/cpython-3.12.9-macos-aarch64-none/lib/python3.12/multiprocessing/process.py", line 314, in _bootstrap
    self.run()
  File "/Users/katasetakumi/.local/share/uv/python/cpython-3.12.9-macos-aarch64-none/lib/python3.12/multiprocessing/process.py", line 108, in run
    self._target(*self._args, **self._kwargs)
  File "/Users/katasetakumi/.local/share/uv/tools/plamo-translate/lib/python3.12/site-packages/plamo_translate/main.py", line 38, in start_mcp_server
    server = mlx_server.PLaMoTranslateServer(log_level=log_level, show_progress=show_progress)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/katasetakumi/.local/share/uv/tools/plamo-translate/lib/python3.12/site-packages/plamo_translate/servers/mlx/server.py", line 52, in __init__
    model, tokenizer, sampler, logits_processors = self.load_model()
                                                   ^^^^^^^^^^^^^^^^^
  File "/Users/katasetakumi/.local/share/uv/tools/plamo-translate/lib/python3.12/site-packages/plamo_translate/servers/mlx/server.py", line 90, in load_model
    subprocess.run(
  File "/Users/katasetakumi/.local/share/uv/python/cpython-3.12.9-macos-aarch64-none/lib/python3.12/subprocess.py", line 550, in run
    with Popen(*popenargs, **kwargs) as process:
         ^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/katasetakumi/.local/share/uv/python/cpython-3.12.9-macos-aarch64-none/lib/python3.12/subprocess.py", line 1028, in __init__
    self._execute_child(args, executable, preexec_fn, close_fds,
  File "/Users/katasetakumi/.local/share/uv/python/cpython-3.12.9-macos-aarch64-none/lib/python3.12/subprocess.py", line 1963, in _execute_child
    raise child_exception_type(errno_num, err_msg, err_filename)
FileNotFoundError: [Errno 2] No such file or directory: 'python'
```
<br>
This PR resolves the above error.

## Changes

- Imported sys module: Added import sys to the file.
- Changed subprocess command: Updated the subprocess.run call from using "python" to sys.executable when executing mlx_lm.