### PR TITLE
Suppress optional GPU dependency warnings on non-Nvidia environments

### DIFF
--- a/src/plamo_translate/servers/mlx/server.py
+++ b/src/plamo_translate/servers/mlx/server.py
@@ -29,6 +29,10 @@ from plamo_translate.servers.utils import (
     find_free_port,
     update_config,
 )
+from plamo_translate.servers.warnings import (
+    build_optional_gpu_dependency_warning_options,
+    suppress_optional_gpu_dependency_warnings,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -86,22 +90,34 @@ class PLaMoTranslateServer(FastMCP):
 
         # Reload mlx_lm.utils here to refleect the environment variables for progress bars
         if self.show_progress:
-            envs = os.environ
+            envs = os.environ.copy()
             envs["HF_HUB_DISABLE_PROGRESS_BARS"] = "0"
             subprocess.run(
-                [sys.executable, "-m", "mlx_lm", "generate", "--model", model_name, "--max-tokens", "1", "--trust-remote-code"],
+                [
+                    sys.executable,
+                    *build_optional_gpu_dependency_warning_options(),
+                    "-m",
+                    "mlx_lm",
+                    "generate",
+                    "--model",
+                    model_name,
+                    "--max-tokens",
+                    "1",
+                    "--trust-remote-code",
+                ],
                 env=envs,
                 stdout=subprocess.DEVNULL,
             )
 
-        model, tokenizer = load(
-            model_name,
-            model_config={"trust_remote_code": True},
-            tokenizer_config={
-                "trust_remote_code": True,
-                "chat_template": chat_template,
-            },
-        )
+        with suppress_optional_gpu_dependency_warnings():
+            model, tokenizer = load(
+                model_name,
+                model_config={"trust_remote_code": True},
+                tokenizer_config={
+                    "trust_remote_code": True,
+                    "chat_template": chat_template,
+                },
+            )
         tokenizer.add_eos_token("<|plamo:op|>")
 
         sampler = make_sampler(

--- a/src/plamo_translate/servers/warnings.py
+++ b/src/plamo_translate/servers/warnings.py
@@ -1,0 +1,30 @@
+import contextlib
+import re
+import warnings
+from collections.abc import Iterator
+
+OPTIONAL_GPU_DEPENDENCY_WARNING_MESSAGES = (
+    "mamba_ssm could not be imported",
+    "causal_conv1d could not be imported",
+)
+
+
+@contextlib.contextmanager
+def suppress_optional_gpu_dependency_warnings() -> Iterator[None]:
+    """Hide known optional dependency warnings emitted by remote model code."""
+    with warnings.catch_warnings():
+        for message in OPTIONAL_GPU_DEPENDENCY_WARNING_MESSAGES:
+            warnings.filterwarnings(
+                action="ignore",
+                message=rf"^{re.escape(message)}$",
+                category=UserWarning,
+            )
+        yield
+
+
+def build_optional_gpu_dependency_warning_options() -> list[str]:
+    """Build `python -W` options that suppress known optional dependency warnings."""
+    options: list[str] = []
+    for message in OPTIONAL_GPU_DEPENDENCY_WARNING_MESSAGES:
+        options.extend(["-W", f"ignore:{message}:UserWarning"])
+    return options

--- a/tests/test_warning_filters.py
+++ b/tests/test_warning_filters.py
@@ -1,0 +1,27 @@
+import warnings
+
+from plamo_translate.servers.warnings import (
+    OPTIONAL_GPU_DEPENDENCY_WARNING_MESSAGES,
+    build_optional_gpu_dependency_warning_options,
+    suppress_optional_gpu_dependency_warnings,
+)
+
+
+def test_build_optional_gpu_dependency_warning_options():
+    assert build_optional_gpu_dependency_warning_options() == [
+        "-W",
+        "ignore:mamba_ssm could not be imported:UserWarning",
+        "-W",
+        "ignore:causal_conv1d could not be imported:UserWarning",
+    ]
+
+
+def test_suppress_optional_gpu_dependency_warnings_only_hides_known_messages():
+    with warnings.catch_warnings(record=True) as captured:
+        warnings.simplefilter("always")
+        with suppress_optional_gpu_dependency_warnings():
+            for message in OPTIONAL_GPU_DEPENDENCY_WARNING_MESSAGES:
+                warnings.warn(message, UserWarning, stacklevel=1)
+            warnings.warn("unexpected warning", UserWarning, stacklevel=1)
+
+    assert [str(item.message) for item in captured] == ["unexpected warning"]


### PR DESCRIPTION
## Summary

Fixes #16.

Suppress the known optional dependency warnings emitted while loading the MLX remote model code on non-Nvidia environments.

## What Changed

- added a small warning helper that targets only the `mamba_ssm` and `causal_conv1d` `UserWarning` messages
- wrapped the MLX `load(...)` call with that targeted suppression
- passed matching `-W ignore:...:UserWarning` flags to the warm-up `mlx_lm generate` subprocess used when showing model loading progress
- added regression tests to verify that only the known optional dependency warnings are suppressed

## Why

The current upstream `mlx-community/plamo-2-translate` remote model code warns when `mamba_ssm` and `causal_conv1d` are unavailable. Those packages are optional for this CLI on macOS and other non-Nvidia environments, so the warnings are noisy even though translation still works correctly.

This keeps the CLI output clean without hiding unrelated warnings or real errors.

## Validation

- `uv run pytest tests/test_warning_filters.py tests/test_cli.py`
- `uv run ruff check src/plamo_translate/servers/mlx/server.py src/plamo_translate/servers/warnings.py tests/test_warning_filters.py`
