### PR TITLE
Fix CI workflow evaluation and Python matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,10 +2,11 @@ name: CI
 
 on:
   push:
+  pull_request:
 
 jobs:
   mock-test:
-    runs-on: macos-latest
+    runs-on: ubuntu-latest
     timeout-minutes: 15
     strategy:
       matrix:
@@ -14,7 +15,7 @@ jobs:
       PLAMO_TRANSLATE_CLI_USE_MOCK_SERVER: '1'
       PLAMO_TRANSLATE_CLI_TEST_TIMEOUT_SECONDS: '20'
       PLAMO_TRANSLATE_CLI_TEST_SERVER_STARTUP_TIMEOUT_SECONDS: '10'
-      UV_CACHE_DIR: ${{ runner.temp }}/uv-cache
+      UV_CACHE_DIR: .cache/uv
     steps:
       - uses: actions/checkout@v4
       - name: Set up Python ${{ matrix.python-version }}
@@ -43,27 +44,27 @@ jobs:
     runs-on: macos-latest
     timeout-minutes: 45
     env:
-      HF_HOME: ${{ runner.temp }}/hf
-      HUGGINGFACE_HUB_CACHE: ${{ runner.temp }}/hf/hub
+      HF_HOME: .cache/hf
+      HUGGINGFACE_HUB_CACHE: .cache/hf/hub
       PLAMO_TRANSLATE_CLI_MODEL_NAME: mlx-community/plamo-2-translate
       PLAMO_TRANSLATE_CLI_MODEL_CACHE_KEY: plamo-2-translate
       PLAMO_TRANSLATE_CLI_USE_MOCK_SERVER: '0'
       PLAMO_TRANSLATE_CLI_TEST_TIMEOUT_SECONDS: '900'
       PLAMO_TRANSLATE_CLI_TEST_SERVER_STARTUP_TIMEOUT_SECONDS: '900'
-      UV_CACHE_DIR: ${{ runner.temp }}/uv-cache
+      UV_CACHE_DIR: .cache/uv
     steps:
       - uses: actions/checkout@v4
-      - name: Set up Python 3.14
+      - name: Set up Python 3.13
         uses: actions/setup-python@v5
         with:
-          python-version: '3.14'
+          python-version: '3.13'
       - name: Cache uv downloads
         uses: actions/cache@v4
         with:
           path: ${{ env.UV_CACHE_DIR }}
-          key: ${{ runner.os }}-uv-py3.14-${{ hashFiles('uv.lock') }}
+          key: ${{ runner.os }}-uv-py3.13-${{ hashFiles('uv.lock') }}
           restore-keys: |
-            ${{ runner.os }}-uv-py3.14-
+            ${{ runner.os }}-uv-py3.13-
             ${{ runner.os }}-uv-
       - name: Cache Hugging Face models
         uses: actions/cache@v4


### PR DESCRIPTION
## Summary
This updates the GitHub Actions workflow so CI jobs are created correctly again and the MLX integration lane runs on a supported Python version.

## Root cause
Recent workflow runs were failing before any job started because the workflow used `${{ runner.temp }}` in job-level `env`, where the `runner` context is not available during workflow evaluation. The most recent failed run showed `Invalid workflow file` annotations and produced no jobs.

A separate earlier failure also showed that `mlx` does not currently publish macOS wheels for Python 3.14, so the integration job could not complete `uv sync` on that interpreter.

## Changes
- add `pull_request` as a trigger so CI also runs for PRs
- move cache directories from `${{ runner.temp }}` to repository-relative paths
- run the mock test matrix on `ubuntu-latest`
- keep the MLX integration test on `macos-latest` but pin it to Python 3.13
- update the integration job's uv cache key to match Python 3.13

## Validation
- `uv run --python 3.13 pytest -s tests/test_cli.py tests/test_warning_filters.py`
- `uv run --python 3.13 python - <<'PY'
  import mlx
  import mlx_lm
  print('mlx ok')
  print('mlx_lm ok')
  PY`
